### PR TITLE
Use auto partition assignment for messages

### DIFF
--- a/app.go
+++ b/app.go
@@ -335,6 +335,7 @@ func (a *App) Run() error {
 						Value:   eosioAction.JSON(),
 						TopicPartition: kafka.TopicPartition{
 							Topic: &a.config.KafkaTopic,
+							Partition: kafka.PartitionAny,
 						},
 					}
 					if err := s.Send(&msg); err != nil {


### PR DESCRIPTION
As explained in the bug https://github.com/dfuse-io/dkafka/issues/5 partition assignment was not working.
Added the missing parameter to the topic.