### PR TITLE
add basic dbop decoding through --local-abi-files and --abicodec-grpc-addr

### DIFF
--- a/abidecoder.go
+++ b/abidecoder.go
@@ -1,0 +1,151 @@
+package dkafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	pbabicodec "github.com/dfuse-io/dfuse-eosio/pb/dfuse/eosio/abicodec/v1"
+	pbcodec "github.com/dfuse-io/dfuse-eosio/pb/dfuse/eosio/codec/v1"
+	"github.com/eoscanada/eos-go"
+)
+
+type ABIDecoder struct {
+	overrides   map[string]*eos.ABI
+	abiCodecCli pbabicodec.DecoderClient
+	abisCache   map[string]*abiItem
+}
+
+func (a *ABIDecoder) IsNOOP() bool {
+	return a.overrides == nil && a.abiCodecCli == nil
+}
+
+// LoadABIFiles will load ABIs for different accounts from JSON files
+func LoadABIFiles(abiFiles map[string]string) (map[string]*eos.ABI, error) {
+	out := make(map[string]*eos.ABI)
+	for contract, abiFile := range abiFiles {
+		f, err := os.Open(abiFile)
+		if err != nil {
+			return nil, fmt.Errorf("opening abi file %s: %w", abiFile, err)
+		}
+		abi, err := eos.NewABI(f)
+		if err != nil {
+			return nil, fmt.Errorf("reading abi file %s: %w", abiFile, err)
+		}
+		out[contract] = abi
+	}
+	return out, nil
+}
+
+func NewABIDecoder(
+	overrides map[string]*eos.ABI,
+	abiCodecCli pbabicodec.DecoderClient,
+) *ABIDecoder {
+	return &ABIDecoder{
+		overrides:   overrides,
+		abiCodecCli: abiCodecCli,
+		abisCache:   make(map[string]*abiItem),
+	}
+}
+
+type decodedDBOp struct {
+	*pbcodec.DBOp
+	NewJSON *json.RawMessage `json:"new_json,omitempty"`
+	OldJSON *json.RawMessage `json:"old_json,omitempty"`
+}
+
+func (a *ABIDecoder) abi(contract string, blockNum uint32) (*eos.ABI, error) {
+	if a.overrides != nil {
+		if abi, ok := a.overrides[contract]; ok {
+			return abi, nil
+		}
+	}
+
+	if a.abiCodecCli == nil {
+		return nil, fmt.Errorf("unable to get abi for contract %q", contract)
+	}
+
+	if abiObj, ok := a.abisCache[contract]; ok {
+		if abiObj.blockNum < blockNum {
+			return abiObj.abi, nil
+		}
+	}
+
+	resp, err := a.abiCodecCli.GetAbi(context.Background(), &pbabicodec.GetAbiRequest{
+		Account:    contract,
+		AtBlockNum: blockNum,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get abi for contract %q: %w", contract, err)
+	}
+
+	var abi *eos.ABI
+	err = json.Unmarshal([]byte(resp.JsonPayload), &abi)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode abi for contract %q: %w", contract, err)
+	}
+
+	// store abi in cache for late uses
+	a.abisCache[contract] = &abiItem{
+		abi:      abi,
+		blockNum: resp.AbiBlockNum,
+	}
+	return abi, nil
+}
+
+func (a *ABIDecoder) DecodeDBOps(in []*pbcodec.DBOp, blockNum uint32) (decodedDBOps []*decodedDBOp, err error) {
+	for _, op := range in {
+		decoded := &decodedDBOp{DBOp: op}
+		decodedDBOps = append(decodedDBOps, decoded)
+	}
+
+	if a.IsNOOP() {
+		return
+	}
+
+	var errors []error
+	for _, op := range decodedDBOps {
+		abi, err := a.abi(op.Code, blockNum)
+		if err != nil {
+			return nil, fmt.Errorf("decoding dbop in block %d: %w", blockNum, err)
+		}
+		tableDef := abi.TableForName(eos.TableName(op.TableName))
+		if tableDef == nil {
+			errors = append(errors, fmt.Errorf("table %s not present in ABI for contract %s", op.TableName, op.Code))
+			continue
+		}
+
+		if len(op.NewData) > 0 {
+			bytes, err := abi.DecodeTableRowTyped(tableDef.Type, op.NewData)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("decode row: %w", err))
+				continue
+			}
+			asJSON := json.RawMessage(bytes)
+			op.NewJSON = &asJSON
+		}
+		if len(op.OldData) > 0 {
+			bytes, err := abi.DecodeTableRowTyped(tableDef.Type, op.OldData)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("decode row: %w", err))
+				continue
+			}
+			asJSON := json.RawMessage(bytes)
+			op.OldJSON = &asJSON
+		}
+	}
+	if len(errors) > 0 {
+		errorStr := ""
+		for _, e := range errors {
+			errorStr = fmt.Sprintf("%s; %s", errorStr, e.Error())
+		}
+		err = fmt.Errorf(errorStr)
+	}
+	return
+}
+
+type abiItem struct {
+	abi      *eos.ABI
+	blockNum uint32
+}

--- a/app.go
+++ b/app.go
@@ -12,9 +12,12 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/dfuse-io/bstream/forkable"
 	"github.com/dfuse-io/dfuse-eosio/filtering"
+	pbabicodec "github.com/dfuse-io/dfuse-eosio/pb/dfuse/eosio/abicodec/v1"
 	pbcodec "github.com/dfuse-io/dfuse-eosio/pb/dfuse/eosio/codec/v1"
+	"github.com/dfuse-io/dgrpc"
 	pbbstream "github.com/dfuse-io/pbgo/dfuse/bstream/v1"
 	pbhealth "github.com/dfuse-io/pbgo/grpc/health/v1"
+	"github.com/eoscanada/eos-go"
 
 	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
@@ -55,6 +58,10 @@ type Config struct {
 	EventKeysExpr        string
 	EventTypeExpr        string
 	EventExtensions      map[string]string
+
+	LocalABIFiles         map[string]string
+	ABICodecGRPCAddr      string
+	FailOnUndecodableDBOP bool
 }
 
 type App struct {
@@ -110,6 +117,31 @@ func (a *App) Run() error {
 		if err != nil {
 			return fmt.Errorf("getting kafka producer: %w", err)
 		}
+	}
+
+	var abiFiles map[string]*eos.ABI
+	if len(a.config.LocalABIFiles) != 0 {
+		abiFiles, err = LoadABIFiles(a.config.LocalABIFiles)
+		if err != nil {
+			return err
+		}
+	}
+
+	var abiCodecClient pbabicodec.DecoderClient
+	if a.config.ABICodecGRPCAddr != "" {
+		abiCodecConn, err := dgrpc.NewInternalClient(a.config.ABICodecGRPCAddr)
+		if err != nil {
+			return fmt.Errorf("setting up abicodec client: %w", err)
+		}
+
+		abiCodecClient = pbabicodec.NewDecoderClient(abiCodecConn)
+	}
+
+	zlog.Info("setting up ABIDecoder")
+	abiDecoder := NewABIDecoder(abiFiles, abiCodecClient)
+
+	if abiDecoder.IsNOOP() && a.config.FailOnUndecodableDBOP {
+		return fmt.Errorf("Invalid config: no abicodec GRPC address and no local ABI file has been set, but fail-on-undecodable-db-op is enabled")
 	}
 
 	var cp checkpointer
@@ -256,6 +288,14 @@ func (a *App) Run() error {
 				if act.Receipt != nil {
 					globalSeq = act.Receipt.GlobalSequence
 				}
+
+				decodedDBOps, err := abiDecoder.DecodeDBOps(trx.DBOpsForAction(act.ExecutionIndex), blk.Number)
+				if err != nil {
+					if a.config.FailOnUndecodableDBOP {
+						return err
+					}
+					zlog.Warn("cannot decode dbops", zap.Uint32("block_number", blk.Number), zap.Error(err))
+				}
 				eosioAction := event{
 					BlockNum:      blk.Number,
 					BlockID:       blk.Id,
@@ -268,7 +308,7 @@ func (a *App) Run() error {
 						Receiver:       act.Receiver,
 						Action:         act.Name(),
 						JSONData:       &jsonData,
-						DBOps:          trx.DBOpsForAction(act.ExecutionIndex),
+						DBOps:          decodedDBOps,
 						Authorization:  auths,
 						GlobalSequence: globalSeq,
 					},
@@ -334,7 +374,7 @@ func (a *App) Run() error {
 						Headers: headers,
 						Value:   eosioAction.JSON(),
 						TopicPartition: kafka.TopicPartition{
-							Topic: &a.config.KafkaTopic,
+							Topic:     &a.config.KafkaTopic,
 							Partition: kafka.PartitionAny,
 						},
 					}

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/dfuse-io/bstream v0.0.2-0.20210125192647-167e31f99b40
 	github.com/dfuse-io/derr v0.0.0-20201001203637-4dc9d8014152
 	github.com/dfuse-io/dfuse-eosio v0.1.1-docker.0.20210128200504-f24b253436ef
+	github.com/dfuse-io/dgrpc v0.0.0-20210118212827-12d9d8a14c40
 	github.com/dfuse-io/dlauncher v0.0.0-20201112212422-91f62bcef971
 	github.com/dfuse-io/logging v0.0.0-20210109005628-b97a57253f70
 	github.com/dfuse-io/pbgo v0.0.6-0.20210125181705-b17235518132
 	github.com/dfuse-io/shutter v1.4.1
+	github.com/eoscanada/eos-go v0.9.1-0.20210115195118-6d94af7a8501
 	github.com/golang/protobuf v1.4.3
 	github.com/google/cel-go v0.6.0
 	github.com/google/go-cmp v0.5.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/prometheus/client_golang v1.2.1
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.3

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,37 @@
+package dkafka
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+)
+
+var (
+	messagesSent = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "dkafka_sent_messages",
+		Help: "The total number of sent messages",
+	})
+	transactionTracesReceived = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "dkafka_received_transaction_traces",
+		Help: "The total number of transaction traces received from firehose",
+	})
+	actionTracesReceived = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "dkafka_received_action_traces",
+		Help: "The total number of action traces received from firehose",
+	})
+	blocksReceived = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "dkafka_received_blocks",
+		Help: "The total number of blocks receivedfrom firehose",
+	})
+)
+
+func startPrometheusMetrics(path string, listenAddr string) {
+	zlog.Info("Starting prometheus HTTP server", zap.String("listen_addr", listenAddr), zap.String("path", path))
+	http.Handle(path, promhttp.Handler())
+	if err := http.ListenAndServe(listenAddr, nil); err != nil {
+		zlog.Warn("prometheus server failed", zap.String("listen_addr", listenAddr), zap.String("path", path), zap.Error(err))
+	}
+}

--- a/publisher.go
+++ b/publisher.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"strings"
 
-	pbcodec "github.com/dfuse-io/dfuse-eosio/pb/dfuse/eosio/codec/v1"
-
 	"github.com/google/cel-go/cel"
 )
 
@@ -26,7 +24,7 @@ type ActionInfo struct {
 	Action         string           `json:"action"`
 	GlobalSequence uint64           `json:"global_seq"`
 	Authorization  []string         `json:"authorizations"`
-	DBOps          []*pbcodec.DBOp  `json:"db_ops"`
+	DBOps          []*decodedDBOp   `json:"db_ops"`
 	JSONData       *json.RawMessage `json:"json_data"`
 }
 

--- a/sender.go
+++ b/sender.go
@@ -101,18 +101,18 @@ func getKafkaSender(producer *kafka.Producer, cp checkpointer, useTransactions b
 type dryRunSender struct{}
 
 type fakeMessage struct {
-	Topic     string   `json:"topic"`
-	Headers   []string `json:"headers"`
-	Partition int      `json:"partition"`
-	Offset    int      `json:"offset"`
-	TS        uint64   `json:"ts"`
-	Key       string   `json:"key"`
-	Payload   string   `json:"payload"`
+	Topic     string          `json:"topic"`
+	Headers   []string        `json:"headers"`
+	Partition int             `json:"partition"`
+	Offset    int             `json:"offset"`
+	TS        uint64          `json:"ts"`
+	Key       string          `json:"key"`
+	Payload   json.RawMessage `json:"payload"`
 }
 
 func (s *dryRunSender) Send(msg *kafka.Message) error {
 	out := &fakeMessage{
-		Payload: string(msg.Value),
+		Payload: json.RawMessage(msg.Value),
 		Key:     string(msg.Key),
 	}
 	for _, h := range msg.Headers {


### PR DESCRIPTION
# DECODE DBOPs on the fly 
* Gets and caches ABI from abicodec GRPC service
* If the decoding of a DBOP fails, it will fetch the new ABI and try with that one.

# Decoding DBOps using ABIs

* --local-abi-files flag allows you to specify local JSON files as ABIs for the contracts for which you want to decode DB operations, ex: `--local-abi-files=eosio.token:./eosio.token.abi,eosio:./eosio.abi`

--abicodec-grpc-addr flag allows you to specify the GRPC address of a dfuse "abicodec" service, so dkafka can fetch the ABIs on demand, ex: `--abicodec-grpc-addr=localhost:9001`

--fail-on-undecodable-db-op flag allows you to specify if you want dkafka to fail any time it cannot decode a given dbop to JSON

